### PR TITLE
* [2026.4.10] - Fixed `strobealign` index support: replaced `-i/--con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 **Changes:**
+* [2026.4.10] - Fixed `strobealign` index support: replaced `-i/--contamination_index` with `-i/--use_index` boolean flag that maps to strobealign's native `--use-index` [issue/#24](https://github.com/jolespin/fastq_preprocessor/issues/24)
+* [2026.4.10] - Added `-c/--compression_level` to `strobealign_split_reads` (default 6) applied to both `samtools fastq -c` and `repair.sh zl=` for consistent gzip compression
 * [2026.4.10] - Added `--bam` flag to `strobealign_split_reads` for coordinate-sorted BAM output
 * [2026.4.10] - Changed `--temporary_prefix` to `-T/--temporary_directory` in `strobealign_split_reads` with task-specific prefixes derived internally
 * [2026.4.10] - Generalized `strobealign_split_reads` consumer architecture to support 1–3 concurrent outputs in any combination

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ optional arguments:
 
 ```
 fastq_preprocessor short -h
-usage: fastq_preprocessor -1 <reads_1.fq> -2 <reads_2.fq> -n <name> -o <output_directory> |Optional| -x <contamination_reference.fasta> | -i <contamination_index> -k <kmer_database>
+usage: fastq_preprocessor -1 <reads_1.fq> -2 <reads_2.fq> -n <name> -o <output_directory> |Optional| -x <contamination_reference.fasta> [-i/--use_index] -k <kmer_database>
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -115,10 +115,9 @@ Fastp arguments:
 
 Strobealign arguments:
   -x CONTAMINATION_FASTA, --contamination_fasta CONTAMINATION_FASTA
-                        Strobealign | path/to/contamination_reference.fasta[.gz] (raw FASTA; index built on the fly)
+                        Strobealign | path/to/contamination_reference.fasta[.gz]
                         (e.g., Human T2T assembly from https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/latest_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz)
-  -i CONTAMINATION_INDEX, --contamination_index CONTAMINATION_INDEX
-                        Strobealign | path/to/contamination_index (pre-built strobealign .sti index; uses --use-index)
+  -i, --use_index       Strobealign | Use pre-built .sti index (must exist next to the FASTA). Maps to strobealign --use-index.
   --retain_trimmed_reads RETAIN_TRIMMED_READS
                         Retain fastp trimmed fastq after decontamination. 0=No, 1=yes [Default: 0]
   --retain_contaminated_reads RETAIN_CONTAMINATED_READS

--- a/fastq_preprocessor/fastq_preprocessor_short.py
+++ b/fastq_preprocessor/fastq_preprocessor_short.py
@@ -164,15 +164,15 @@ def get_strobealign_cmd(input_filepaths, output_filepaths, output_directory, dir
         mapped_fastq=os.path.join(output_directory, "contaminated_%.fastq.gz"),
     )
 
-    # Build extra args: --use-index if pre-built index, plus user-supplied options
+    # Build extra args: --use-index flag, plus user-supplied options
     strobealign_extra_args = []
-    if opts.contamination_index:
+    if opts.use_index:
         strobealign_extra_args.append("--use-index")
     if opts.strobealign_options:
         strobealign_extra_args += opts.strobealign_options.split()
 
     # Generate bash script via strobealign wrapper
-    bash_script = strobealign_build_cmd(strobealign_opts, strobealign_extra_args)
+    bash_script = strobealign_build_cmd(strobealign_opts, strobealign_extra_args, compression_level=6)
 
     # Ensure conda bin is in PATH for bare tool names used by build_cmd
     path_prefix = "export PATH={}:$PATH".format(os.path.join(os.environ["CONDA_PREFIX"], "bin"))
@@ -531,15 +531,7 @@ def configure_parameters(opts, directories):
     assert_acceptable_arguments(opts.retain_trimmed_reads, {0, 1})
     assert_acceptable_arguments(opts.retain_contaminated_reads, {0, 1})
 
-    # Resolve contamination reference
-    # When using a pre-built index (-i), strobealign still expects the FASTA as the
-    # positional argument and finds the .sti file automatically based on the FASTA path.
-    # So we derive the FASTA path by stripping the .rXXX.sti suffix from the index path.
-    if opts.contamination_index:
-        fasta_path = opts.contamination_index.rsplit(".r", 1)[0]
-        opts.contamination_reference = fasta_path
-    else:
-        opts.contamination_reference = opts.contamination_fasta
+    opts.contamination_reference = opts.contamination_fasta
 
     # Set environment variables
     add_executables_to_environment(opts=opts)
@@ -551,7 +543,7 @@ def main(args=None):
     # Path info
     description = """
     Running: {} v{} via Python v{} | {}""".format(__program__, __version__, sys.version.split(" ")[0], sys.executable)
-    usage = "{} -1 <reads_1.fq> -2 <reads_2.fq> -n <n> -o <output_directory> |Optional| -x <contamination_reference.fasta> | -i <contamination_index> -k <kmer_database>".format(__program__)
+    usage = "{} -1 <reads_1.fq> -2 <reads_2.fq> -n <n> -o <output_directory> |Optional| -x <contamination_reference.fasta> [-i/--use_index] -k <kmer_database>".format(__program__)
     epilog = "Copyright 2022 Josh L. Espinoza (jespinoz@jcvi.org)"
 
     # Parser
@@ -580,9 +572,8 @@ def main(args=None):
 
     # Strobealign
     parser_strobealign = parser.add_argument_group('Strobealign arguments')
-    contamination_group = parser_strobealign.add_mutually_exclusive_group()
-    contamination_group.add_argument("-x", "--contamination_fasta", type=str, help="Strobealign | path/to/contamination_reference.fasta[.gz] (raw FASTA; index built on the fly)\n(e.g., Human T2T assembly from https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/latest_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz)")
-    contamination_group.add_argument("-i", "--contamination_index", type=str, help="Strobealign | path/to/contamination_index (pre-built strobealign .sti index; uses --use-index)")
+    parser_strobealign.add_argument("-x", "--contamination_fasta", type=str, help="Strobealign | path/to/contamination_reference.fasta[.gz]\n(e.g., Human T2T assembly from https://ftp.ncbi.nlm.nih.gov/genomes/refseq/vertebrate_mammalian/Homo_sapiens/latest_assembly_versions/GCF_009914755.1_T2T-CHM13v2.0/GCF_009914755.1_T2T-CHM13v2.0_genomic.fna.gz)")
+    parser_strobealign.add_argument("-i", "--use_index", action="store_true", default=False, help="Strobealign | Use pre-built .sti index (must exist next to the FASTA). Maps to strobealign --use-index.")
     parser_strobealign.add_argument("--retain_trimmed_reads", default=0, type=int, help = "Retain fastp trimmed fastq after decontamination. 0=No, 1=yes [Default: 0]")
     parser_strobealign.add_argument("--retain_contaminated_reads", default=0, type=int, help = "Retain contaminated fastq after decontamination. 0=No, 1=yes [Default: 0]")
     parser_strobealign.add_argument("--strobealign_options", type=str, default="", help="Strobealign | More options (e.g. --arg 1 ) [Default: '']\nhttps://github.com/ksahlin/strobealign")

--- a/fastq_preprocessor/strobealign_split_reads.py
+++ b/fastq_preprocessor/strobealign_split_reads.py
@@ -62,17 +62,18 @@ def resolve_output_paths(path):
         }
 
 
-def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_info, no_repair):
+def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_info, no_repair, compression_level=6):
     paired = output_info["paired"]
 
     if paired and not no_repair:
         # Paired with repair
         cmd = (
-            "samtools fastq -@ {threads} {flag} -0 /dev/null -s /dev/null -n {input}"
-            " | repair.sh repair=t overwrite=t threads=1 in=stdin.fastq"
+            "samtools fastq -@ {threads} -c {compression_level} {flag} -0 /dev/null -s /dev/null -n {input}"
+            " | repair.sh repair=t overwrite=t zl={compression_level} threads=1 in=stdin.fastq"
             " out1={out1} out2={out2}"
         ).format(
             threads=samtools_threads,
+            compression_level=compression_level,
             flag=samtools_flag,
             input=fifo_or_stdin,
             out1=output_info["path_1"],
@@ -81,11 +82,12 @@ def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_in
     elif paired and no_repair:
         # Paired without repair
         cmd = (
-            "samtools fastq -@ {threads} {flag}"
+            "samtools fastq -@ {threads} -c {compression_level} {flag}"
             " -1 {out1} -2 {out2}"
             " -0 /dev/null -s /dev/null -n {input}"
         ).format(
             threads=samtools_threads,
+            compression_level=compression_level,
             flag=samtools_flag,
             out1=output_info["path_1"],
             out2=output_info["path_2"],
@@ -94,11 +96,12 @@ def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_in
     elif not paired and not no_repair:
         # Interleaved with repair
         cmd = (
-            "samtools fastq -@ {threads} {flag} -0 /dev/null -s /dev/null -n {input}"
-            " | repair.sh repair=t overwrite=t threads=1 in=stdin.fastq"
+            "samtools fastq -@ {threads} -c {compression_level} {flag} -0 /dev/null -s /dev/null -n {input}"
+            " | repair.sh repair=t overwrite=t zl={compression_level} threads=1 in=stdin.fastq"
             " out={out}"
         ).format(
             threads=samtools_threads,
+            compression_level=compression_level,
             flag=samtools_flag,
             input=fifo_or_stdin,
             out=output_info["path"],
@@ -106,11 +109,12 @@ def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_in
     else:
         # Interleaved without repair
         cmd = (
-            "samtools fastq -@ {threads} {flag}"
+            "samtools fastq -@ {threads} -c {compression_level} {flag}"
             " -0 /dev/null -s /dev/null -n {input}"
             " > {out}"
         ).format(
             threads=samtools_threads,
+            compression_level=compression_level,
             flag=samtools_flag,
             input=fifo_or_stdin,
             out=output_info["path"],
@@ -119,7 +123,7 @@ def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_in
     return cmd
 
 
-def build_cmd(opts, strobealign_extra_args):
+def build_cmd(opts, strobealign_extra_args, compression_level=6):
     parts = []
 
     # Resolve output paths
@@ -164,11 +168,11 @@ def build_cmd(opts, strobealign_extra_args):
     consumers = []
     if has_mapped:
         consumers.append(("mapped", build_consumer_cmd(
-            "-F 12", opts.samtools_threads, None, mapped_info, opts.no_repair,
+            "-F 12", opts.samtools_threads, None, mapped_info, opts.no_repair, compression_level,
         )))
     if has_unmapped:
         consumers.append(("unmapped", build_consumer_cmd(
-            "-f 12", opts.samtools_threads, None, unmapped_info, opts.no_repair,
+            "-f 12", opts.samtools_threads, None, unmapped_info, opts.no_repair, compression_level,
         )))
     if has_bam:
         consumers.append(("bam", "samtools sort -@ {threads} -T {tmp} -o {out} -".format(
@@ -277,6 +281,7 @@ def main(args=None):
     parser_utility.add_argument("-t", "--threads", type=int, default=1, help="Threads for strobealign [Default: 1]")
     parser_utility.add_argument("--samtools_threads", type=int, default=1, help="Threads for samtools fastq/sort [Default: 1]")
     parser_utility.add_argument("--no_repair", action="store_true", default=False, help="Disable repair.sh post-processing")
+    parser_utility.add_argument("-c", "--compression_level", type=int, default=6, help="Compression level [0..9] for samtools fastq bgzf output [Default: 6]")
     parser_utility.add_argument("-T", "--temporary_directory", type=str, default="/tmp/strobealign_split_reads",
                                 help="Temporary directory for samtools collate/sort and named pipes [Default: /tmp/strobealign_split_reads]")
     parser_utility.add_argument("-v", "--version", action="version", version="{} v{}".format(__program__, __version__))
@@ -328,13 +333,14 @@ def main(args=None):
     logger.info("Threads: {}", opts.threads)
     logger.info("Samtools threads: {}", opts.samtools_threads)
     logger.info("Repair: {}", not opts.no_repair)
+    logger.info("Compression level: {}", opts.compression_level)
     logger.info("Temporary directory: {}", opts.temporary_directory)
     if strobealign_extra_args:
         logger.info("Strobealign extra args: {}", " ".join(strobealign_extra_args))
     logger.info("=" * 60)
 
     # Build and execute
-    cmd_str = build_cmd(opts, strobealign_extra_args)
+    cmd_str = build_cmd(opts, strobealign_extra_args, compression_level=opts.compression_level)
     logger.info("Command:\n{}", cmd_str)
     run(["bash", "-c", cmd_str], check=True)
     logger.success("Completed successfully")


### PR DESCRIPTION
  Bug #24: Fix strobealign index support

  Problem: -i/--contamination_index treated .sti files as standalone references, deriving the FASTA path by stripping .rXXX.sti. This is wrong — strobealign always requires the FASTA file; the .sti is a companion file.

  Fix: Removed -i/--contamination_index. Repurposed -i as a boolean flag -i/--use_index that maps directly to strobealign's native --use-index. Users now always provide the FASTA via -x and optionally add -i for pre-built index usage.

  Files changed:
  - fastq_preprocessor/fastq_preprocessor_short.py — argparse, configure_parameters(), get_strobealign_cmd(), usage string
  - README.md — usage string and help block

  Compression level fix

  Problem: Cleaned FASTQ files were significantly larger than trimmed files despite having fewer reads. Two causes:
  1. samtools fastq defaults to bgzf compression level 1 (for direct file writes)
  2. repair.sh defaults to zl=2

  Fix: Added compression_level parameter (default 6) threaded through build_consumer_cmd() → build_cmd(). Applied as -c 6 on samtools fastq and zl=6 on repair.sh.

  Files changed:
  - fastq_preprocessor/strobealign_split_reads.py — build_consumer_cmd(), build_cmd(), CLI arg, logging

  Remaining size gap: After fixing compression levels (109M → 102M), cleaned files are still slightly larger than trimmed per-read because samtools collate reorders reads by name, destroying sequencer locality that gzip exploits. This is inherent to the collate/repair
  pipeline.