### PR TITLE
Renamed `strobealign_split_reads` to `strobealign_wrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **Changes:**
+* [2026.4.10] - Renamed `strobealign_split_reads` to `strobealign_wrapper` to better reflect broader purpose (BAM output, future coverage support) [issue/#25](https://github.com/jolespin/fastq_preprocessor/issues/25)
 * [2026.4.10] - Fixed `strobealign` index support: replaced `-i/--contamination_index` with `-i/--use_index` boolean flag that maps to strobealign's native `--use-index` [issue/#24](https://github.com/jolespin/fastq_preprocessor/issues/24)
 * [2026.4.10] - Added `-c/--compression_level` to `strobealign_split_reads` (default 6) applied to both `samtools fastq -c` and `repair.sh zl=` for consistent gzip compression
 * [2026.4.10] - Added `--bam` flag to `strobealign_split_reads` for coordinate-sorted BAM output

--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ BBDuk arguments:
                         BBDuk | More options (e.g., --arg 1) [Default: '']
 ```
 
-**Split aligned reads with strobealign (`strobealign_split_reads`)**
+**Strobealign wrapper (`strobealign_wrapper`)**
 
-Wraps `strobealign` to split aligned output into mapped and unmapped paired-end FASTQ files — analogous to bowtie2's `--al-conc` / `--un-conc` flags. All unrecognized arguments are forwarded directly to `strobealign`.
+Wraps `strobealign` to split aligned output into mapped and unmapped paired-end FASTQ files and/or coordinate-sorted BAM files. All unrecognized arguments are forwarded directly to `strobealign`.
 
 ```
-strobealign_split_reads -h
-usage: strobealign_split_reads [strobealign_options] reference reads1 reads2 --mapped_fastq PATH --unmapped_fastq PATH
+strobealign_wrapper -h
+usage: strobealign_wrapper [strobealign_options] reference reads1 reads2 --mapped_fastq PATH --unmapped_fastq PATH --bam PATH
 
 Required I/O arguments:
   reference             Reference FASTA for strobealign
@@ -230,14 +230,14 @@ Utility arguments:
   -t, --threads         Threads for strobealign [Default: 1]
   --samtools_threads    Threads for samtools fastq gzip compression [Default: 1]
   --no_repair           Disable repair.sh post-processing
-  -T, --temporary_prefix
-                        Temp prefix for samtools collate and named pipes [Default: /tmp/strobealign_split_reads]
+  -T, --temporary_directory
+                        Temporary directory for samtools collate/sort and named pipes [Default: /tmp/strobealign_wrapper]
   -v, --version         show program's version number and exit
 ```
 
 Example — split into paired files:
 ```
-strobealign_split_reads -t 8 \
+strobealign_wrapper -t 8 \
   reference.fasta.gz \
   reads_1.fastq.gz \
   reads_2.fastq.gz \
@@ -247,7 +247,7 @@ strobealign_split_reads -t 8 \
 
 Example — split into interleaved files:
 ```
-strobealign_split_reads -t 8 \
+strobealign_wrapper -t 8 \
   reference.fasta.gz \
   reads_1.fastq.gz \
   reads_2.fastq.gz \

--- a/fastq_preprocessor/fastq_preprocessor_short.py
+++ b/fastq_preprocessor/fastq_preprocessor_short.py
@@ -8,7 +8,7 @@ import pandas as pd
 from loguru import logger
 
 from ._utils import create_directory, format_path, assert_acceptable_arguments, Pipeline
-from .strobealign_split_reads import build_cmd as strobealign_build_cmd
+from .strobealign_wrapper import build_cmd as strobealign_build_cmd
 
 pd.options.display.max_colwidth = 100
 

--- a/fastq_preprocessor/strobealign_wrapper.py
+++ b/fastq_preprocessor/strobealign_wrapper.py
@@ -282,8 +282,8 @@ def main(args=None):
     parser_utility.add_argument("--samtools_threads", type=int, default=1, help="Threads for samtools fastq/sort [Default: 1]")
     parser_utility.add_argument("--no_repair", action="store_true", default=False, help="Disable repair.sh post-processing")
     parser_utility.add_argument("-c", "--compression_level", type=int, default=6, help="Compression level [0..9] for samtools fastq bgzf output [Default: 6]")
-    parser_utility.add_argument("-T", "--temporary_directory", type=str, default="/tmp/strobealign_split_reads",
-                                help="Temporary directory for samtools collate/sort and named pipes [Default: /tmp/strobealign_split_reads]")
+    parser_utility.add_argument("-T", "--temporary_directory", type=str, default="/tmp/strobealign_wrapper",
+                                help="Temporary directory for samtools collate/sort and named pipes [Default: /tmp/strobealign_wrapper]")
     parser_utility.add_argument("-v", "--version", action="version", version="{} v{}".format(__program__, __version__))
 
     # Parse

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='fastq_preprocessor',
             'fastq_preprocessor=fastq_preprocessor.fastq_preprocessor:main',
             'fastq_preprocessor_short=fastq_preprocessor.fastq_preprocessor_short:main',
             'fastq_preprocessor_long=fastq_preprocessor.fastq_preprocessor_long:main',
-            'strobealign_split_reads=fastq_preprocessor.strobealign_split_reads:main',
+            'strobealign_wrapper=fastq_preprocessor.strobealign_wrapper:main',
         ],
     },
 


### PR DESCRIPTION
## Summary
  - Renamed `strobealign_split_reads` to `strobealign_wrapper` to better reflect its broader purpose — the module now produces coordinate-sorted BAM files in addition to splitting mapped/unmapped FASTQ, with coverage output planned next
  - Updated all references: module file, import in `fastq_preprocessor_short`, `setup.py` entry point, README documentation, and CHANGELOG
  - No functional changes — all existing behavior is preserved under the new name

  Closes #25

  ## Files changed
  - `fastq_preprocessor/strobealign_split_reads.py` → `fastq_preprocessor/strobealign_wrapper.py` (renamed + updated default temp dir)
  - `fastq_preprocessor/fastq_preprocessor_short.py` (updated import)
  - `setup.py` (updated entry point)
  - `README.md` (updated section header, description, usage, and examples)
  - `CHANGELOG.md` (added rename entry)

  ## Test plan
  - [x] `strobealign_wrapper -h` — new entry point works
  - [x] `strobealign_wrapper` with paired FASTQ output (`--mapped_fastq`/`--unmapped_fastq` with `%`)
  - [x] `strobealign_wrapper` with interleaved FASTQ output (no `%`)
  - [x] `strobealign_wrapper` with `--bam` only
  - [x] `strobealign_wrapper` with all three outputs (mapped + unmapped + BAM)
  - [x] `fastq_preprocessor short` without decontamination
  - [x] `fastq_preprocessor short` with decontamination (`-x`)
  - [x] `grep -r strobealign_split_reads .` — only matches CHANGELOG historical entries