### PR TITLE
Added `--coverage` and `--depth` flags to `strobealign_wrapper` for `samtools coverage` and `samtools depth` output from BAM files issue/#22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **Changes:**
+* [2026.4.13] - Added `--coverage` and `--depth` flags to `strobealign_wrapper` for `samtools coverage` and `samtools depth` output from BAM files [issue/#22](https://github.com/jolespin/fastq_preprocessor/issues/22)
 * [2026.4.10] - Renamed `strobealign_split_reads` to `strobealign_wrapper` to better reflect broader purpose (BAM output, future coverage support) [issue/#25](https://github.com/jolespin/fastq_preprocessor/issues/25)
 * [2026.4.10] - Fixed `strobealign` index support: replaced `-i/--contamination_index` with `-i/--use_index` boolean flag that maps to strobealign's native `--use-index` [issue/#24](https://github.com/jolespin/fastq_preprocessor/issues/24)
 * [2026.4.10] - Added `-c/--compression_level` to `strobealign_split_reads` (default 6) applied to both `samtools fastq -c` and `repair.sh zl=` for consistent gzip compression

--- a/README.md
+++ b/README.md
@@ -225,11 +225,16 @@ Required I/O arguments:
   --unmapped_fastq      Output path for unmapped reads.
                         Use % for paired: unmapped_%.fastq.gz -> unmapped_1.fastq.gz, unmapped_2.fastq.gz
                         Without %: interleaved output. % is replaced with 1 or 2.
+  --bam                 Output path for coordinate-sorted BAM file
+  --coverage            Run samtools coverage on BAM and write {bam}.coverage.tsv (requires --bam)
+  --depth               Run samtools depth -a on BAM and write {bam}.depth.tsv (requires --bam)
 
 Utility arguments:
   -t, --threads         Threads for strobealign [Default: 1]
-  --samtools_threads    Threads for samtools fastq gzip compression [Default: 1]
+  --samtools_threads    Threads for samtools fastq/sort [Default: 1]
   --no_repair           Disable repair.sh post-processing
+  -c, --compression_level
+                        Compression level [0..9] for samtools fastq bgzf output [Default: 6]
   -T, --temporary_directory
                         Temporary directory for samtools collate/sort and named pipes [Default: /tmp/strobealign_wrapper]
   -v, --version         show program's version number and exit
@@ -253,5 +258,15 @@ strobealign_wrapper -t 8 \
   reads_2.fastq.gz \
   --mapped_fastq output/mapped.fastq.gz \
   --unmapped_fastq output/unmapped.fastq.gz
+```
+
+Example — BAM with coverage and depth stats:
+```
+strobealign_wrapper -t 8 \
+  reference.fasta.gz \
+  reads_1.fastq.gz \
+  reads_2.fastq.gz \
+  --bam output/aligned.bam \
+  --coverage --depth
 ```
 

--- a/fastq_preprocessor/__init__.py
+++ b/fastq_preprocessor/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-__version__= "2026.4.10"
+__version__= "2026.4.13"
 __author__ = "Josh L. Espinoza"
 __email__ = "jespinoz@jcvi.org, jol.espinoz@gmail.com"
 __url__ = "https://github.com/jolespin/fastq_preprocessor"

--- a/fastq_preprocessor/strobealign_wrapper.py
+++ b/fastq_preprocessor/strobealign_wrapper.py
@@ -123,7 +123,7 @@ def build_consumer_cmd(samtools_flag, samtools_threads, fifo_or_stdin, output_in
     return cmd
 
 
-def build_cmd(opts, strobealign_extra_args, compression_level=6):
+def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False, depth=False):
     parts = []
 
     # Resolve output paths
@@ -224,6 +224,15 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6):
         parts.append("wait")
         parts.append("rm -f {}".format(" ".join(fifos)))
 
+    if (coverage or depth) and has_bam:
+        parts.append("")
+        post_cmds = ["samtools index {}".format(bam_path)]
+        if coverage:
+            post_cmds.append("samtools coverage {bam} > {bam}.coverage.tsv".format(bam=bam_path))
+        if depth:
+            post_cmds.append("samtools depth -a -H {bam} > {bam}.depth.tsv".format(bam=bam_path))
+        parts.append(" \\\n&& ".join(post_cmds))
+
     return "\n".join(parts)
 
 
@@ -276,6 +285,10 @@ def main(args=None):
                            help="Output path for unmapped reads.\nUse %% for paired: unmapped_%%.fastq.gz -> unmapped_1.fastq.gz, unmapped_2.fastq.gz\nWithout %%: interleaved output")
     parser_io.add_argument("--bam", type=str, default=None,
                            help="Output path for coordinate-sorted BAM file")
+    parser_io.add_argument("--coverage", action="store_true", default=False,
+                           help="Run samtools coverage on BAM and write {bam}.coverage.tsv (requires --bam)")
+    parser_io.add_argument("--depth", action="store_true", default=False,
+                           help="Run samtools depth -a on BAM and write {bam}.depth.tsv (requires --bam)")
 
     parser_utility = parser.add_argument_group('Utility arguments')
     parser_utility.add_argument("-t", "--threads", type=int, default=1, help="Threads for strobealign [Default: 1]")
@@ -292,6 +305,9 @@ def main(args=None):
     # Validate
     if opts.mapped_fastq is None and opts.unmapped_fastq is None and opts.bam is None:
         parser.error("At least one of --mapped_fastq, --unmapped_fastq, or --bam must be provided")
+
+    if (opts.coverage or opts.depth) and opts.bam is None:
+        parser.error("--coverage and --depth require --bam to be provided")
 
     for label, path in [("--mapped_fastq", opts.mapped_fastq), ("--unmapped_fastq", opts.unmapped_fastq)]:
         if path is not None and path.count("%") > 1:
@@ -330,6 +346,8 @@ def main(args=None):
     logger.info("Mapped FASTQ: {}", opts.mapped_fastq)
     logger.info("Unmapped FASTQ: {}", opts.unmapped_fastq)
     logger.info("BAM: {}", opts.bam)
+    logger.info("Coverage: {}", opts.coverage)
+    logger.info("Depth: {}", opts.depth)
     logger.info("Threads: {}", opts.threads)
     logger.info("Samtools threads: {}", opts.samtools_threads)
     logger.info("Repair: {}", not opts.no_repair)
@@ -340,7 +358,8 @@ def main(args=None):
     logger.info("=" * 60)
 
     # Build and execute
-    cmd_str = build_cmd(opts, strobealign_extra_args, compression_level=opts.compression_level)
+    cmd_str = build_cmd(opts, strobealign_extra_args, compression_level=opts.compression_level,
+                        coverage=opts.coverage, depth=opts.depth)
     logger.info("Command:\n{}", cmd_str)
     run(["bash", "-c", cmd_str], check=True)
     logger.success("Completed successfully")


### PR DESCRIPTION

  Summary

  - Added --coverage and --depth flags to strobealign_wrapper that run samtools coverage and samtools depth -a -H on the BAM output, producing {bam}.coverage.tsv and {bam}.depth.tsv respectively
  - Both flags require --bam to be provided; BAM is automatically indexed via samtools index before computing stats
  - Post-processing commands are &&-chained for fail-fast behavior
  - Backward compatible: new build_cmd() params default to False, existing callers unaffected
  - Updated CHANGELOG.md and README.md with new flags, usage docs, and example

  Closes #22

  Test plan

  - --coverage or --depth without --bam produces parser error: "require --bam to be provided"
  - --bam alone produces only the BAM file (no index, coverage, or depth files)
  - --bam --coverage --depth produces BAM + .bai index + .coverage.tsv (per-contig stats with header) + .depth.tsv (per-position depth with header)
  - Dry-run inspection of generated bash commands for single-consumer and multi-consumer cases shows correct samtools index && samtools coverage && samtools depth chaining
