### PR TITLE
Symlink `fastp` `.html`/`.json` and `fastplong` `.html`/`.json` report files to the output directory 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **Changes:**
+* [2026.4.13] - Symlink `fastp` `.html`/`.json` and `fastplong` `.html`/`.json` report files to the output directory [issue/#30](https://github.com/jolespin/fastq_preprocessor/issues/30)
 * [2026.4.13] - Added `--coverage` and `--depth` flags to `strobealign_wrapper` for `samtools coverage` and `samtools depth` output from BAM files [issue/#22](https://github.com/jolespin/fastq_preprocessor/issues/22)
 * [2026.4.10] - Renamed `strobealign_split_reads` to `strobealign_wrapper` to better reflect broader purpose (BAM output, future coverage support) [issue/#25](https://github.com/jolespin/fastq_preprocessor/issues/25)
 * [2026.4.10] - Fixed `strobealign` index support: replaced `-i/--contamination_index` with `-i/--use_index` boolean flag that maps to strobealign's native `--use-index` [issue/#24](https://github.com/jolespin/fastq_preprocessor/issues/24)

--- a/fastq_preprocessor/fastq_preprocessor_long.py
+++ b/fastq_preprocessor/fastq_preprocessor_long.py
@@ -409,6 +409,8 @@ def create_pipeline(opts, directories, f_cmds):
     # i/o
     input_filepaths = [
         os.path.join(directories["intermediate"], "*", "*.fastq.gz"),
+        os.path.join(directories["intermediate"], "1__fastplong", "fastplong.html"),
+        os.path.join(directories["intermediate"], "1__fastplong", "fastplong.json"),
     ]
 
     output_filenames = map(lambda fp: fp.split("/")[-1], input_filepaths)

--- a/fastq_preprocessor/fastq_preprocessor_short.py
+++ b/fastq_preprocessor/fastq_preprocessor_short.py
@@ -493,6 +493,8 @@ def create_pipeline(opts, directories, f_cmds):
     # i/o
     input_filepaths = [
         os.path.join(directories["intermediate"], "*", "*.fastq.gz"),
+        os.path.join(directories["intermediate"], "1__fastp", "fastp.html"),
+        os.path.join(directories["intermediate"], "1__fastp", "fastp.json"),
     ]
 
     output_filenames = map(lambda fp: fp.split("/")[-1], input_filepaths)


### PR DESCRIPTION
Symlink `fastp` `.html`/`.json` and `fastplong` `.html`/`.json` report files to the output directory [issue/#30](https://github.com/jolespin/fastq_preprocessor/issues/30)