### PR TITLE
Added stability and scalability changes along with a new `coverage_breadth` CLI script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 TASK.md
 CLAUDE.md
 .claude/
+tmp/
 
 # Ignore Python distribution artifacts
 *.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 **Changes:**
+* [2026.4.17] - Added `-c/--compression_level` to `fastq_preprocessor_short` (applied to `repair.sh zl=`) and `fastq_preprocessor_long` (applied to `pigz`) for configurable gzip compression of output FASTQ files (default: 6)
+* [2026.4.17] - Added random run ID (8-character hex UUID) to `strobealign_wrapper` temporary file names (FIFOs, `samtools collate`/`sort` prefixes) to prevent collisions during simultaneous runs; temporary files are removed on both success and failure via `atexit`
+* [2026.4.17] - Changed `samtools depth -a` to `samtools depth -aa` in `strobealign_wrapper` to include all positions even for contigs with no mapped reads
 * [2026.4.13] - Symlink `fastp` `.html`/`.json` and `fastplong` `.html`/`.json` report files to the output directory [issue/#30](https://github.com/jolespin/fastq_preprocessor/issues/30)
 * [2026.4.13] - Added `--coverage` and `--depth` flags to `strobealign_wrapper` for `samtools coverage` and `samtools depth` output from BAM files [issue/#22](https://github.com/jolespin/fastq_preprocessor/issues/22)
 * [2026.4.10] - Renamed `strobealign_split_reads` to `strobealign_wrapper` to better reflect broader purpose (BAM output, future coverage support) [issue/#25](https://github.com/jolespin/fastq_preprocessor/issues/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **Changes:**
+* [2026.4.17] - Added `coverage_breadth` CLI tool that computes genome-level coverage breadth (ratio of bases covered at ≥ `--minimum_depth`) from `samtools depth` (with or without `-aa`) or `samtools coverage` output; outputs a single `percentage_of_bases_covered\t<value>` row (0–100 scale) to stdout or a file
 * [2026.4.17] - Added `-c/--compression_level` to `fastq_preprocessor_short` (applied to `repair.sh zl=`) and `fastq_preprocessor_long` (applied to `pigz`) for configurable gzip compression of output FASTQ files (default: 6)
 * [2026.4.17] - Added random run ID (8-character hex UUID) to `strobealign_wrapper` temporary file names (FIFOs, `samtools collate`/`sort` prefixes) to prevent collisions during simultaneous runs; temporary files are removed on both success and failure via `atexit`
 * [2026.4.17] - Changed `samtools depth -a` to `samtools depth -aa` in `strobealign_wrapper` to include all positions even for contigs with no mapped reads

--- a/README.md
+++ b/README.md
@@ -261,3 +261,53 @@ strobealign_wrapper -t 8 \
   --coverage --depth
 ```
 
+**Coverage breadth (`coverage_breadth`)**
+
+Computes genome-level coverage breadth (percentage of bases covered at ≥ `--minimum_depth` (0–100 scale)) from `samtools depth` or `samtools coverage` output. Outputs a single tab-separated row: `percentage_of_bases_covered\t<value>`. Either `--depth` or `--coverage` must be provided (not both). If `--depth` was generated without `-aa`, provide `--fasta` for reference lengths. `--minimum_depth > 1` is only supported with `--depth`.
+
+```
+coverage_breadth -h
+usage: coverage_breadth (--depth PATH | --coverage PATH) [--fasta PATH] [-o PATH] [--minimum_depth INT]
+
+Required I/O arguments:
+  --depth               Path to samtools depth TSV.
+                        If generated with -aa, all positions are present (--fasta not needed).
+                        If generated without -aa, provide --fasta for reference lengths.
+  --fasta               Reference FASTA (required when samtools depth was run without -aa)
+  --coverage            Path to samtools coverage TSV
+  -o, --output          Output path [Default: stdout]
+
+Parameter arguments:
+  --minimum_depth       Minimum depth to count a position as covered [Default: 1]
+
+Utility arguments:
+  -v, --version         show program's version number and exit
+```
+
+Example — from `samtools depth -aa` output:
+```
+coverage_breadth \
+  --depth output/aligned.bam.depth.tsv
+```
+
+Example — from `samtools depth` (without `-aa`), using FASTA for reference lengths:
+```
+coverage_breadth \
+  --depth output/aligned.bam.depth.tsv \
+  --fasta reference.fasta.gz
+```
+
+Example — from `samtools coverage` output:
+```
+coverage_breadth \
+  --coverage output/aligned.bam.coverage.tsv
+```
+
+Example — custom minimum depth, write to file:
+```
+coverage_breadth \
+  --depth output/aligned.bam.depth.tsv \
+  --minimum_depth 5 \
+  -o output/coverage_breadth.tsv
+```
+

--- a/fastq_preprocessor/__init__.py
+++ b/fastq_preprocessor/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-__version__= "2026.4.13"
+__version__= "2026.4.17"
 __author__ = "Josh L. Espinoza"
 __email__ = "jespinoz@jcvi.org, jol.espinoz@gmail.com"
 __url__ = "https://github.com/jolespin/fastq_preprocessor"

--- a/fastq_preprocessor/coverage_breadth.py
+++ b/fastq_preprocessor/coverage_breadth.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, division
+import sys, os, argparse, gzip
+
+import pandas as pd
+
+__program__ = os.path.split(sys.argv[0])[-1]
+from fastq_preprocessor import __version__
+
+
+def parse_fasta_lengths(fasta_path):
+    opener = gzip.open if fasta_path.endswith('.gz') else open
+    lengths = {}
+    name, length = None, 0
+    with opener(fasta_path, 'rt') as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if line.startswith('>'):
+                if name is not None:
+                    lengths[name] = length
+                name = line[1:].split()[0]
+                length = 0
+            else:
+                length += len(line)
+    if name is not None:
+        lengths[name] = length
+    return lengths
+
+
+def main(args=None):
+    description = """
+    Running: {} v{} via Python v{} | {}""".format(
+        __program__, __version__, sys.version.split(" ")[0], sys.executable,
+    )
+    usage = "{} (--depth PATH | --coverage PATH) [--fasta PATH] [-o PATH] [--minimum_depth INT]".format(__program__)
+
+    parser = argparse.ArgumentParser(
+        description=description,
+        usage=usage,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    parser_io = parser.add_argument_group('Required I/O arguments')
+    parser_io.add_argument('--depth', type=str, default=None,
+                           help='Path to samtools depth TSV.\nIf generated with -aa, all positions are present (--fasta not needed).\nIf generated without -aa, provide --fasta for reference lengths.')
+    parser_io.add_argument('--fasta', type=str, default=None,
+                           help='Reference FASTA (required when samtools depth was run without -aa)')
+    parser_io.add_argument('--coverage', type=str, default=None,
+                           help='Path to samtools coverage TSV')
+    parser_io.add_argument('-o', '--output', type=str, default='-',
+                           help='Output path [Default: stdout]')
+
+    parser_params = parser.add_argument_group('Parameter arguments')
+    parser_params.add_argument('--minimum_depth', type=int, default=1,
+                               help='Minimum depth to count a position as covered [Default: 1]')
+
+    parser_utility = parser.add_argument_group('Utility arguments')
+    parser_utility.add_argument('-v', '--version', action='version',
+                                version='{} v{}'.format(__program__, __version__))
+
+    opts = parser.parse_args(args)
+
+    # Validate
+    if opts.depth is None and opts.coverage is None:
+        parser.error('Must provide --depth or --coverage')
+    if opts.depth is not None and opts.coverage is not None:
+        parser.error('Cannot provide both --depth and --coverage')
+    if opts.coverage is not None and opts.minimum_depth > 1:
+        parser.error('--minimum_depth > 1 is not supported with --coverage; use --depth with -aa instead')
+
+    # Compute
+    if opts.coverage is not None:
+        # Mode A: samtools coverage TSV
+        df = pd.read_csv(opts.coverage, sep='\t')
+        df.columns = [col.lstrip('#') for col in df.columns]
+        total_length = int((df['endpos'] - df['startpos'] + 1).sum())
+        total_covered = int(df['covbases'].sum())
+    elif opts.fasta is not None:
+        # Mode C: samtools depth without -aa; use FASTA lengths for total positions
+        df = pd.read_csv(opts.depth, sep='\t', comment='#', header=None,
+                         names=['id', 'position', 'depth'])
+        fasta_lengths = parse_fasta_lengths(opts.fasta)
+        total_length = sum(fasta_lengths.values())
+        total_covered = int((df['depth'] >= opts.minimum_depth).sum())
+    else:
+        # Mode B: samtools depth with -aa; all positions present in file
+        df = pd.read_csv(opts.depth, sep='\t', comment='#', header=None,
+                         names=['id', 'position', 'depth'])
+        total_length = len(df)
+        total_covered = int((df['depth'] >= opts.minimum_depth).sum())
+
+    percentage = total_covered / total_length * 100
+    output_line = 'percentage_of_bases_covered\t{}\n'.format(percentage)
+
+    if opts.output == '-':
+        sys.stdout.write(output_line)
+    else:
+        with open(opts.output, 'w') as f:
+            f.write(output_line)
+
+
+if __name__ == '__main__':
+    main()

--- a/fastq_preprocessor/fastq_preprocessor_long.py
+++ b/fastq_preprocessor/fastq_preprocessor_long.py
@@ -78,6 +78,7 @@ def get_minimap2_cmd(input_filepaths, output_filepaths, output_directory, direct
     "-",
     "|",
     os.environ["pigz"],
+    "-{}".format(opts.compression_level),
     "-p {}".format(opts.n_jobs),
     ">",
     os.path.join(output_directory, "contaminated.fastq.gz"),
@@ -95,6 +96,7 @@ def get_minimap2_cmd(input_filepaths, output_filepaths, output_directory, direct
     "-",
     "|",
     os.environ["pigz"],
+    "-{}".format(opts.compression_level),
     "-p {}".format(opts.n_jobs),
     ">",
     os.path.join(output_directory, "cleaned.fastq.gz"),
@@ -472,6 +474,7 @@ def main(args=None):
     parser_utility = parser.add_argument_group('Utility arguments')
     parser_utility.add_argument("--path_config", type=str,  default="CONDA_PREFIX", help="path/to/config.tsv. Must have at least 2 columns [name, executable] [Default: CONDA_PREFIX]")  #site-packges in future
     parser_utility.add_argument("-p", "--n_jobs", type=int, default=1, help = "Number of threads [Default: 1]")
+    parser_utility.add_argument("-c", "--compression_level", type=int, default=6, help="Compression level [1..9] for gzipped FASTQ output [Default: 6]")
     parser_utility.add_argument("--random_state", type=int, default=0, help = "Random state [Default: 0]")
     parser_utility.add_argument("--restart_from_checkpoint", type=int, help = "Restart from a particular checkpoint")
     parser_utility.add_argument("-v", "--version", action='version', version="{} v{}".format(__program__, __version__))

--- a/fastq_preprocessor/fastq_preprocessor_short.py
+++ b/fastq_preprocessor/fastq_preprocessor_short.py
@@ -49,6 +49,7 @@ def get_fastp_cmd(input_filepaths, output_filepaths, output_directory, directori
     "out2={}".format(os.path.join(output_directory, "trimmed_2.fastq.gz")),
     # "outs={}".format(os.path.join(output_directory, "trimmed_singletons.fastq.gz")),
     "overwrite=t",
+    "zl={}".format(opts.compression_level),
     ")",
     # Seqkit
     "&&",
@@ -172,7 +173,7 @@ def get_strobealign_cmd(input_filepaths, output_filepaths, output_directory, dir
         strobealign_extra_args += opts.strobealign_options.split()
 
     # Generate bash script via strobealign wrapper
-    bash_script = strobealign_build_cmd(strobealign_opts, strobealign_extra_args, compression_level=6)
+    bash_script = strobealign_build_cmd(strobealign_opts, strobealign_extra_args, compression_level=opts.compression_level)
 
     # Ensure conda bin is in PATH for bare tool names used by build_cmd
     path_prefix = "export PATH={}:$PATH".format(os.path.join(os.environ["CONDA_PREFIX"], "bin"))
@@ -561,6 +562,7 @@ def main(args=None):
     parser_utility = parser.add_argument_group('Utility arguments')
     parser_utility.add_argument("--path_config", type=str,  default="CONDA_PREFIX", help="path/to/config.tsv. Must have at least 2 columns [name, executable] [Default: CONDA_PREFIX]")  #site-packges in future
     parser_utility.add_argument("-p", "--n_jobs", type=int, default=1, help = "Number of threads [Default: 1]")
+    parser_utility.add_argument("-c", "--compression_level", type=int, default=6, help="Compression level [1..9] for gzipped FASTQ output [Default: 6]")
     parser_utility.add_argument("--random_state", type=int, default=0, help = "Random state [Default: 0]")
     parser_utility.add_argument("--restart_from_checkpoint", type=int, help = "Restart from a particular checkpoint")
     parser_utility.add_argument("-v", "--version", action='version', version="{} v{}".format(__program__, __version__))

--- a/fastq_preprocessor/strobealign_wrapper.py
+++ b/fastq_preprocessor/strobealign_wrapper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function, division
-import sys, os, argparse, atexit
+import sys, os, argparse, atexit, uuid
 from subprocess import (
     run,
     PIPE,
@@ -22,6 +22,7 @@ from fastq_preprocessor import __version__
 # FIFO cleanup
 # =============
 fifo_paths = []
+run_id = uuid.uuid4().hex[:8]
 
 def cleanup_fifos():
     for p in fifo_paths:
@@ -156,7 +157,7 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False,
             r2=opts.reads2,
         ),
         "samtools view -h -",
-        "samtools collate -u -O - {prefix}".format(prefix=os.path.join(opts.temporary_directory, "samtools_collate")),
+        "samtools collate -u -O - {prefix}".format(prefix=os.path.join(opts.temporary_directory, "samtools_collate_{}".format(run_id))),
     ]
     producer = " | ".join(producer_tokens)
 
@@ -177,7 +178,7 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False,
     if has_bam:
         consumers.append(("bam", "samtools sort -@ {threads} -T {tmp} -o {out} -".format(
             threads=opts.samtools_threads,
-            tmp=os.path.join(opts.temporary_directory, "samtools_sort"),
+            tmp=os.path.join(opts.temporary_directory, "samtools_sort_{}".format(run_id)),
             out=bam_path,
         )))
 
@@ -197,7 +198,7 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False,
         # Last consumer reads from stdout via >
         fifos = []
         for i, (label, consumer_cmd) in enumerate(consumers[:-1]):
-            fifo = os.path.join(opts.temporary_directory, "{}_fifo".format(label))
+            fifo = os.path.join(opts.temporary_directory, "{}_{}_fifo".format(label, run_id))
             fifos.append(fifo)
             fifo_paths.append(fifo)
             consumer_cmd = _set_consumer_input(consumer_cmd, label, fifo)
@@ -206,7 +207,7 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False,
 
         # Last consumer reads from the final fifo via >
         last_label, last_consumer_cmd = consumers[-1]
-        last_fifo = os.path.join(opts.temporary_directory, "{}_fifo".format(last_label))
+        last_fifo = os.path.join(opts.temporary_directory, "{}_{}_fifo".format(last_label, run_id))
         fifos.append(last_fifo)
         fifo_paths.append(last_fifo)
         last_consumer_cmd = _set_consumer_input(last_consumer_cmd, last_label, last_fifo)
@@ -230,7 +231,7 @@ def build_cmd(opts, strobealign_extra_args, compression_level=6, coverage=False,
         if coverage:
             post_cmds.append("samtools coverage {bam} > {bam}.coverage.tsv".format(bam=bam_path))
         if depth:
-            post_cmds.append("samtools depth -a -H {bam} > {bam}.depth.tsv".format(bam=bam_path))
+            post_cmds.append("samtools depth -aa -H {bam} > {bam}.depth.tsv".format(bam=bam_path))
         parts.append(" \\\n&& ".join(post_cmds))
 
     return "\n".join(parts)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name='fastq_preprocessor',
             'fastq_preprocessor_short=fastq_preprocessor.fastq_preprocessor_short:main',
             'fastq_preprocessor_long=fastq_preprocessor.fastq_preprocessor_long:main',
             'strobealign_wrapper=fastq_preprocessor.strobealign_wrapper:main',
+            'coverage_breadth=fastq_preprocessor.coverage_breadth:main',
         ],
     },
 


### PR DESCRIPTION
* [2026.4.17] - Added `coverage_breadth` CLI tool that computes genome-level coverage breadth (ratio of bases covered at ≥ `--minimum_depth`) from `samtools depth` (with or without `-aa`) or `samtools coverage` output; outputs a single `percentage_of_bases_covered\t<value>` row (0–100 scale) to stdout or a file
* [2026.4.17] - Added `-c/--compression_level` to `fastq_preprocessor_short` (applied to `repair.sh zl=`) and `fastq_preprocessor_long` (applied to `pigz`) for configurable gzip compression of output FASTQ files (default: 6)
* [2026.4.17] - Added random run ID (8-character hex UUID) to `strobealign_wrapper` temporary file names (FIFOs, `samtools collate`/`sort` prefixes) to prevent collisions during simultaneous runs; temporary files are removed on both success and failure via `atexit`
* [2026.4.17] - Changed `samtools depth -a` to `samtools depth -aa` in `strobealign_wrapper` to include all positions even for contigs with no mapped reads